### PR TITLE
feat: add minimal api skeleton and tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+.env
+*.pyc
+*.pyo
+*.pyd
+openapi/openapi.json

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,108 @@
+from fastapi import FastAPI, Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from pydantic import BaseModel
+from datetime import datetime, timedelta
+from typing import Optional
+
+app = FastAPI(title="MediaHub API")
+
+security = HTTPBearer()
+
+FAKE_TOKEN = "fake-jwt"
+TOKEN_EXP_HOURS = 72
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class LoginResponse(BaseModel):
+    token: str
+    role: str
+    exp: datetime
+
+
+class FetchTask(BaseModel):
+    infohash: Optional[str] = None
+    uri: Optional[str] = None
+
+
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}
+
+
+@app.post("/auth/login", response_model=LoginResponse)
+async def auth_login(payload: LoginRequest):
+    # NOTE: This is a stub implementation. Replace with real authentication.
+    role = "admin" if payload.username == "admin" else "user"
+    exp = datetime.utcnow() + timedelta(hours=TOKEN_EXP_HOURS)
+    return LoginResponse(token=FAKE_TOKEN, role=role, exp=exp)
+
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    if credentials.scheme.lower() != "bearer" or credentials.credentials != FAKE_TOKEN:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    return True
+
+
+@app.get("/auth/verify")
+async def auth_verify(_: bool = Depends(verify_token)):
+    return {"status": "ok"}
+
+
+@app.get("/search")
+async def search(q: Optional[str] = None):
+    # Placeholder search implementation
+    return {"results": [], "query": q}
+
+
+@app.post("/tasks/fetch")
+async def tasks_fetch(task: FetchTask, _: bool = Depends(verify_token)):
+    # Stub: accept task and return queued status
+    if not (task.infohash or task.uri):
+        raise HTTPException(status_code=400, detail="infohash or uri required")
+    return {"status": "queued"}
+
+
+@app.get("/items/{item_id}")
+async def get_item(item_id: str):
+    # Stub item retrieval
+    return {"id": item_id, "title": "Sample Item"}
+
+
+@app.post("/items/{item_id}/favorite")
+async def favorite_item(item_id: str, _: bool = Depends(verify_token)):
+    return {"id": item_id, "favorited": True}
+
+
+@app.delete("/items/{item_id}")
+async def delete_item(item_id: str, _: bool = Depends(verify_token)):
+    return {"id": item_id, "deleted": True}
+
+
+@app.get("/catalog/{kind}")
+async def catalog_list(kind: str):
+    if kind not in {"actors", "tags"}:
+        raise HTTPException(status_code=404, detail="unknown catalog")
+    return {"items": []}
+
+
+@app.get("/catalog/{kind}/{item_id}")
+async def catalog_detail(kind: str, item_id: str):
+    if kind not in {"actors", "tags"}:
+        raise HTTPException(status_code=404, detail="unknown catalog")
+    return {"id": item_id, "kind": kind}
+
+
+@app.post("/webhooks/fetcher_done")
+async def fetcher_done(payload: dict):
+    # Stub handler for fetcher completion webhook
+    return {"received": payload}
+
+
+@app.post("/jobs/done")
+async def jobs_done(payload: dict):
+    # Stub handler for processing completion
+    return {"received": payload}

--- a/compose.serve.yml
+++ b/compose.serve.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+services:
+  api:
+    build: .
+    command: uvicorn api.main:app --host 0.0.0.0 --port 8000
+    volumes:
+      - ./:/app
+    ports:
+      - "8000:8000"
+    environment:
+      - PYTHONPATH=/app
+  redis:
+    image: redis:7
+  app-postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: mediahub
+      POSTGRES_USER: mediahub
+      POSTGRES_PASSWORD: example
+    volumes:
+      - app-postgres-data:/var/lib/postgresql/data
+  minio:
+    image: minio/minio
+    command: server /data
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
+    volumes:
+      - minio-data:/data
+    ports:
+      - "9000:9000"
+volumes:
+  app-postgres-data:
+  minio-data:

--- a/compose.transcode.yml
+++ b/compose.transcode.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  worker-ffmpeg:
+    image: jrottenberg/ffmpeg:4.4-alpine
+    volumes:
+      - ./worker/inbox:/inbox
+      - ./worker/outbox:/outbox
+  rclone-agent:
+    image: rclone/rclone
+    command: "rclone sync /outbox minio:"
+    volumes:
+      - ./worker/outbox:/outbox
+      - rclone-config:/config/rclone
+volumes:
+  rclone-config:

--- a/openapi/export.py
+++ b/openapi/export.py
@@ -1,0 +1,25 @@
+"""Export OpenAPI schema for MediaHub API."""
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+# Ensure project root is in path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+
+from api.main import app
+
+
+def main():
+    schema = app.openapi()
+    base = Path(__file__).resolve().parent
+    json_path = base / "openapi.json"
+    yaml_path = base / "openapi.yaml"
+    json_path.write_text(json.dumps(schema, indent=2))
+    yaml_path.write_text(yaml.safe_dump(schema, sort_keys=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,352 @@
+openapi: 3.1.0
+info:
+  title: MediaHub API
+  version: 0.1.0
+paths:
+  /healthz:
+    get:
+      summary: Healthz
+      operationId: healthz_healthz_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /auth/login:
+    post:
+      summary: Auth Login
+      operationId: auth_login_auth_login_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/verify:
+    get:
+      summary: Auth Verify
+      operationId: auth_verify_auth_verify_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+      security:
+      - HTTPBearer: []
+  /search:
+    get:
+      summary: Search
+      operationId: search_search_get
+      parameters:
+      - name: q
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Q
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /tasks/fetch:
+    post:
+      summary: Tasks Fetch
+      operationId: tasks_fetch_tasks_fetch_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FetchTask'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
+  /items/{item_id}:
+    get:
+      summary: Get Item
+      operationId: get_item_items__item_id__get
+      parameters:
+      - name: item_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Item Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      summary: Delete Item
+      operationId: delete_item_items__item_id__delete
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: item_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Item Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /items/{item_id}/favorite:
+    post:
+      summary: Favorite Item
+      operationId: favorite_item_items__item_id__favorite_post
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: item_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Item Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /catalog/{kind}:
+    get:
+      summary: Catalog List
+      operationId: catalog_list_catalog__kind__get
+      parameters:
+      - name: kind
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Kind
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /catalog/{kind}/{item_id}:
+    get:
+      summary: Catalog Detail
+      operationId: catalog_detail_catalog__kind___item_id__get
+      parameters:
+      - name: kind
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Kind
+      - name: item_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Item Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /webhooks/fetcher_done:
+    post:
+      summary: Fetcher Done
+      operationId: fetcher_done_webhooks_fetcher_done_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              type: object
+              title: Payload
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /jobs/done:
+    post:
+      summary: Jobs Done
+      operationId: jobs_done_jobs_done_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              type: object
+              title: Payload
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    FetchTask:
+      properties:
+        infohash:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Infohash
+        uri:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Uri
+      type: object
+      title: FetchTask
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    LoginRequest:
+      properties:
+        username:
+          type: string
+          title: Username
+        password:
+          type: string
+          title: Password
+      type: object
+      required:
+      - username
+      - password
+      title: LoginRequest
+    LoginResponse:
+      properties:
+        token:
+          type: string
+          title: Token
+        role:
+          type: string
+          title: Role
+        exp:
+          type: string
+          format: date-time
+          title: Exp
+      type: object
+      required:
+      - token
+      - role
+      - exp
+      title: LoginResponse
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+  securitySchemes:
+    HTTPBearer:
+      type: http
+      scheme: bearer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+pydantic
+PyYAML
+pytest
+httpx

--- a/scripts/on-complete.sh
+++ b/scripts/on-complete.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# qBittorrent on completion script
+# Usage: on-complete.sh "%I" "%N" "%R"
+INFOHASH="$1"
+NAME="$2"
+ROOT="$3"
+WEBHOOK_URL="${API_PUBLIC_BASE:-http://api:8000}/webhooks/fetcher_done"
+
+echo "Notifying API of completed download: $INFOHASH" >&2
+curl -s -X POST "$WEBHOOK_URL" \
+  -H 'Content-Type: application/json' \
+  -d "{\"hash\": \"$INFOHASH\", \"name\": \"$NAME\", \"root\": \"$ROOT\"}"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from api.main import app
+
+client = TestClient(app)
+
+def test_healthz():
+    response = client.get('/healthz')
+    assert response.status_code == 200
+    assert response.json() == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- scaffold FastAPI app with authentication, search, catalog, and webhook stubs
- add OpenAPI export script and generated spec
- include docker compose templates, qBittorrent completion script, and health check test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d3df88a54832aac18e428bddf354e