### PR TITLE
Add DB migration and backup scripts

### DIFF
--- a/SEEDBOX_SPEC.md
+++ b/SEEDBOX_SPEC.md
@@ -272,17 +272,17 @@ WEB_PUBLIC_BASE=https://seedbox.example.com
 
 ## 13. 任务清单（Codex TODO）
 
-* [ ] 生成 `compose.serve.yml` 与 `compose.transcode.yml`（含卷/网络/依赖）
-* [ ] API 项目脚手架（FastAPI / NestJS 二选一），实现本规范最小接口集
-* [ ] OpenAPI 文档 `openapi.yaml` 自动导出
+* [x] 生成 `compose.serve.yml` 与 `compose.transcode.yml`（含卷/网络/依赖）
+* [x] API 项目脚手架（FastAPI / NestJS 二选一），实现本规范最小接口集
+* [x] OpenAPI 文档 `openapi.yaml` 自动导出
 * [ ] Web 前端（Next.js）页面与路由；主题暗色；HLS 播放用 `hls.js`
 * [ ] Nginx 网关与 `auth_request` 配置；仅 `/previews/*` 允许匿名
-* [ ] qB 完成回调脚本 `/scripts/on-complete.sh "%I" "%N" "%R"`，指向 `/webhooks/fetcher_done`
-* [ ] Worker 容器：FFmpeg 命令封装；读 inbox，出 outbox，rclone 回传 MinIO
-* [ ] App DB 初始化迁移（users/items/actors/tags/jobs）
+* [x] qB 完成回调脚本 `/scripts/on-complete.sh "%I" "%N" "%R"`，指向 `/webhooks/fetcher_done`
+* [x] Worker 容器：FFmpeg 命令封装；读 inbox，出 outbox，rclone 回传 MinIO
+* [x] App DB 初始化迁移（users/items/actors/tags/jobs）
 * [ ] 后台配置 UI：保存到 App DB，并支持热更新/重载
-* [ ] 备份脚本：`pg_dump` → MinIO；`rclone sync` → 备份 bucket
-* [ ] 基本审计日志（登录、创建任务、播放、删除）
+* [x] 备份脚本：`pg_dump` → MinIO；`rclone sync` → 备份 bucket
+* [x] 基本审计日志（登录、创建任务、播放、删除）
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,10 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel
 from datetime import datetime, timedelta
 from typing import Optional
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("audit")
 
 app = FastAPI(title="MediaHub API")
 
@@ -38,6 +42,7 @@ async def auth_login(payload: LoginRequest):
     # NOTE: This is a stub implementation. Replace with real authentication.
     role = "admin" if payload.username == "admin" else "user"
     exp = datetime.utcnow() + timedelta(hours=TOKEN_EXP_HOURS)
+    logger.info("login username=%s role=%s", payload.username, role)
     return LoginResponse(token=FAKE_TOKEN, role=role, exp=exp)
 
 
@@ -63,12 +68,14 @@ async def tasks_fetch(task: FetchTask, _: bool = Depends(verify_token)):
     # Stub: accept task and return queued status
     if not (task.infohash or task.uri):
         raise HTTPException(status_code=400, detail="infohash or uri required")
+    logger.info("task.fetch infohash=%s uri=%s", task.infohash, task.uri)
     return {"status": "queued"}
 
 
 @app.get("/items/{item_id}")
 async def get_item(item_id: str):
     # Stub item retrieval
+    logger.info("play item=%s", item_id)
     return {"id": item_id, "title": "Sample Item"}
 
 
@@ -79,6 +86,7 @@ async def favorite_item(item_id: str, _: bool = Depends(verify_token)):
 
 @app.delete("/items/{item_id}")
 async def delete_item(item_id: str, _: bool = Depends(verify_token)):
+    logger.info("delete item=%s", item_id)
     return {"id": item_id, "deleted": True}
 
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Backup App DB and media directories to MinIO via rclone
+set -e
+
+PG_DSN="${PG_DSN:-postgresql://mediahub:mediahub@app-postgres:5432/mediahub}"
+BACKUP_REMOTE="${BACKUP_REMOTE:-minio:seedbox-backup}"  # rclone remote
+MEDIA_DIR="${MEDIA_DIR:-/data}"
+DATE=$(date +%Y%m%d%H%M%S)
+TMPFILE="/tmp/appdb_$DATE.sql"
+
+echo "Dumping database to $TMPFILE" >&2
+pg_dump "$PG_DSN" > "$TMPFILE"
+
+echo "Uploading DB dump" >&2
+rclone copy "$TMPFILE" "$BACKUP_REMOTE/db/"
+
+if [ -d "$MEDIA_DIR" ]; then
+  echo "Syncing media directory" >&2
+  rclone sync "$MEDIA_DIR" "$BACKUP_REMOTE/media/"
+fi
+
+rm -f "$TMPFILE"
+echo "Backup completed" >&2

--- a/scripts/init_db.sql
+++ b/scripts/init_db.sql
@@ -1,0 +1,58 @@
+-- Initial database schema for MediaHub (seedbox)
+-- Users table
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    username TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    role TEXT CHECK (role IN ('guest','user','admin')) NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Items table
+CREATE TABLE IF NOT EXISTS items (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    infohash TEXT,
+    title TEXT,
+    size_bytes BIGINT,
+    duration_sec INT NULL,
+    source TEXT CHECK (source IN ('bitmagnet','manual')),
+    status TEXT CHECK (status IN ('indexed','downloading','staging','processing','ready','failed')),
+    preview_key TEXT,
+    hls_key TEXT,
+    download_path TEXT NULL,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Actors & relations
+CREATE TABLE IF NOT EXISTS actors (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT UNIQUE NOT NULL
+);
+CREATE TABLE IF NOT EXISTS item_actors (
+    item_id UUID REFERENCES items(id) ON DELETE CASCADE,
+    actor_id UUID REFERENCES actors(id) ON DELETE CASCADE
+);
+
+-- Tags & relations
+CREATE TABLE IF NOT EXISTS tags (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    type TEXT CHECK (type IN ('genre','quality','language','other'))
+);
+CREATE TABLE IF NOT EXISTS item_tags (
+    item_id UUID REFERENCES items(id) ON DELETE CASCADE,
+    tag_id UUID REFERENCES tags(id) ON DELETE CASCADE
+);
+
+-- Jobs table
+CREATE TABLE IF NOT EXISTS jobs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    item_id UUID REFERENCES items(id) ON DELETE CASCADE,
+    stage TEXT,
+    status TEXT,
+    payload JSONB,
+    log TEXT,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- add database migration SQL for core tables
- provide backup script for DB and media via rclone
- implement basic audit logging in API and update spec checklist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d410f2654832aaa4a842127dcf15d