### PR TITLE
feat: add nginx gateway with auth_request

### DIFF
--- a/SEEDBOX_SPEC.md
+++ b/SEEDBOX_SPEC.md
@@ -276,7 +276,7 @@ WEB_PUBLIC_BASE=https://seedbox.example.com
 * [x] API 项目脚手架（FastAPI / NestJS 二选一），实现本规范最小接口集
 * [x] OpenAPI 文档 `openapi.yaml` 自动导出
 * [ ] Web 前端（Next.js）页面与路由；主题暗色；HLS 播放用 `hls.js`
-* [ ] Nginx 网关与 `auth_request` 配置；仅 `/previews/*` 允许匿名
+* [x] Nginx 网关与 `auth_request` 配置；仅 `/previews/*` 允许匿名
 * [x] qB 完成回调脚本 `/scripts/on-complete.sh "%I" "%N" "%R"`，指向 `/webhooks/fetcher_done`
 * [x] Worker 容器：FFmpeg 命令封装；读 inbox，出 outbox，rclone 回传 MinIO
 * [x] App DB 初始化迁移（users/items/actors/tags/jobs）

--- a/compose.serve.yml
+++ b/compose.serve.yml
@@ -9,6 +9,14 @@ services:
       - "8000:8000"
     environment:
       - PYTHONPATH=/app
+  gateway:
+    image: nginx:1.25-alpine
+    depends_on:
+      - api
+    volumes:
+      - ./gateway/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "8080:80"
   redis:
     image: redis:7
   app-postgres:

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+
+    # Internal endpoint for auth_request
+    location = /_auth {
+        internal;
+        proxy_pass http://api:8000/auth/verify;
+        proxy_set_header Authorization $http_authorization;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+    }
+
+    # Allow anonymous preview access
+    location /previews/ {
+        proxy_pass http://api:8000/previews/;
+    }
+
+    # Protect all other routes
+    location / {
+        auth_request /_auth;
+        proxy_pass http://api:8000;
+    }
+}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from api.main import app
+
+client = TestClient(app)
+
+
+def test_auth_verify_requires_token():
+    resp = client.get("/auth/verify")
+    assert resp.status_code == 403
+
+
+def test_auth_verify_with_token():
+    headers = {"Authorization": "Bearer fake-jwt"}
+    resp = client.get("/auth/verify", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"


### PR DESCRIPTION
## Summary
- add nginx reverse proxy with auth_request protecting API routes except `/previews/*`
- expose gateway in compose setup
- test token verification endpoint used by auth_request
- mark nginx task complete in spec

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d42926554832ab708877b91f6888a