### PR TITLE
Add qBittorrent to serve compose for bundled services

### DIFF
--- a/compose.serve.yml
+++ b/compose.serve.yml
@@ -37,6 +37,20 @@ services:
       - minio-data:/data
     ports:
       - "9000:9000"
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:latest
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=UTC
+      - WEBUI_PORT=8080
+    volumes:
+      - qb-conf:/config
+      - qb-downloads:/downloads
+      - ./scripts:/scripts:ro
+    restart: unless-stopped
 volumes:
   app-postgres-data:
   minio-data:
+  qb-conf:
+  qb-downloads:


### PR DESCRIPTION
## Summary
- include qBittorrent in `compose.serve.yml` so the server bundle contains all supporting services

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d6622e8b8832a9c6c8feeee950cfe