### PR TITLE
feat: add deployment script and persistent data dirs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # ===============================================
 # Common settings (configure on both serve & transcode nodes)
 # ===============================================
+DATA_DIR=/opt/seedbox
 MINIO_ENDPOINT=http://minio:9000
 MINIO_ACCESS_KEY=CHANGE_ME
 MINIO_SECRET_KEY=CHANGE_ME

--- a/compose.serve.yml
+++ b/compose.serve.yml
@@ -19,6 +19,8 @@ services:
       - "8080:80"
   redis:
     image: redis:7
+    volumes:
+      - ${DATA_DIR}/redis:/data
   app-postgres:
     image: postgres:15
     environment:
@@ -26,7 +28,7 @@ services:
       POSTGRES_USER: mediahub
       POSTGRES_PASSWORD: example
     volumes:
-      - app-postgres-data:/var/lib/postgresql/data
+      - ${DATA_DIR}/app-postgres:/var/lib/postgresql/data
   minio:
     image: minio/minio
     command: server /data
@@ -34,7 +36,7 @@ services:
       MINIO_ACCESS_KEY: minio
       MINIO_SECRET_KEY: minio123
     volumes:
-      - minio-data:/data
+      - ${DATA_DIR}/minio:/data
     ports:
       - "9000:9000"
   qbittorrent:
@@ -45,12 +47,7 @@ services:
       - TZ=UTC
       - WEBUI_PORT=8080
     volumes:
-      - qb-conf:/config
-      - qb-downloads:/downloads
+      - ${DATA_DIR}/qbittorrent/config:/config
+      - ${DATA_DIR}/qbittorrent/downloads:/downloads
       - ./scripts:/scripts:ro
     restart: unless-stopped
-volumes:
-  app-postgres-data:
-  minio-data:
-  qb-conf:
-  qb-downloads:

--- a/compose.transcode.yml
+++ b/compose.transcode.yml
@@ -3,13 +3,11 @@ services:
   worker-ffmpeg:
     image: jrottenberg/ffmpeg:4.4-alpine
     volumes:
-      - ./worker/inbox:/inbox
-      - ./worker/outbox:/outbox
+      - ${DATA_DIR}/worker/inbox:/inbox
+      - ${DATA_DIR}/worker/outbox:/outbox
   rclone-agent:
     image: rclone/rclone
     command: "rclone sync /outbox minio:"
     volumes:
-      - ./worker/outbox:/outbox
-      - rclone-config:/config/rclone
-volumes:
-  rclone-config:
+      - ${DATA_DIR}/worker/outbox:/outbox
+      - ${DATA_DIR}/rclone:/config/rclone

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_DIR"
+
+# Update repository
+if [ -d .git ]; then
+  echo "Updating repository..."
+  git pull --rebase
+fi
+
+# Create .env if missing
+if [ ! -f .env ]; then
+  echo "Generating .env configuration..."
+  while IFS= read -r line; do
+    if [[ -z "$line" || "$line" =~ ^# ]]; then
+      echo "$line" >> .env
+    else
+      var="${line%%=*}"
+      default="${line#*=}"
+      read -p "Enter value for $var [$default]: " value
+      value=${value:-$default}
+      echo "$var=$value" >> .env
+    fi
+  done < .env.example
+fi
+
+set -a
+source .env
+set +a
+
+DATA_DIR=${DATA_DIR:-/opt/seedbox}
+
+mkdir -p \
+  "$DATA_DIR/redis" \
+  "$DATA_DIR/app-postgres" \
+  "$DATA_DIR/minio" \
+  "$DATA_DIR/qbittorrent/config" \
+  "$DATA_DIR/qbittorrent/downloads" \
+  "$DATA_DIR/worker/inbox" \
+  "$DATA_DIR/worker/outbox" \
+  "$DATA_DIR/rclone"
+
+# Deploy services
+docker compose -f compose.serve.yml -f compose.transcode.yml up -d


### PR DESCRIPTION
## Summary
- add DATA_DIR config and map all service volumes under it
- create deploy.sh for cloning/updating repo and spinning up services

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d70d569ac832abef80707739ab921