### PR TITLE
chore: configure default env and data dir

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@
 # ===============================================
 DATA_DIR=/opt/seedbox
 MINIO_ENDPOINT=http://minio:9000
-MINIO_ACCESS_KEY=CHANGE_ME
-MINIO_SECRET_KEY=CHANGE_ME
+MINIO_ACCESS_KEY=minio
+MINIO_SECRET_KEY=minio123
 MINIO_BUCKET_PREVIEWS=previews
 MINIO_BUCKET_HLS=hls
 
@@ -13,19 +13,19 @@ MINIO_BUCKET_HLS=hls
 # ===============================================
 APP_DB_NAME=mediahub
 APP_DB_USER=mediahub
-APP_DB_PASS=CHANGE_ME
+APP_DB_PASS=example
 APP_DB_HOST=app-postgres
 APP_DB_PORT=5432
 
 BITMAGNET_RO_DSN=postgresql://ro_user:CHANGE@bitmagnet-db:5432/bitmagnet
 REDIS_URL=redis://redis:6379/0
 
-JWT_SECRET=CHANGE_ME
+JWT_SECRET=dev-secret
 JWT_EXP_HOURS=72
 
 QBT_BASEURL=http://qbittorrent:8080
 QBT_USER=admin
-QBT_PASS=CHANGE_ME
+QBT_PASS=adminadmin
 
 API_PUBLIC_BASE=https://api.example.com
 WEB_PUBLIC_BASE=https://seedbox.example.com

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ MediaHub 是一个面向自有/授权媒体内容的受控获取与展示系统�
 
 2. 根据节点类型编辑 `.env`：
 
+    模板已预设 Redis、MinIO 等默认配置，可直接使用或按需修改。
+
     - **共同配置**（两台机器都需要）
+      - `DATA_DIR`：持久化数据目录，默认 `/opt/seedbox`。
       - `MINIO_ENDPOINT`、`MINIO_ACCESS_KEY`、`MINIO_SECRET_KEY`、`MINIO_BUCKET_PREVIEWS`、`MINIO_BUCKET_HLS`：对象存储 MinIO 信息。
     - **serve 节点专用**（仅在下载/展示节点填写）
       - `APP_DB_NAME`、`APP_DB_USER`、`APP_DB_PASS`、`APP_DB_HOST`、`APP_DB_PORT`：内部数据库。

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,7 +30,7 @@ set -a
 source .env
 set +a
 
-DATA_DIR=${DATA_DIR:-/opt/seedbox}
+export DATA_DIR=${DATA_DIR:-/opt/seedbox}
 
 mkdir -p \
   "$DATA_DIR/redis" \


### PR DESCRIPTION
## Summary
- add default credentials for MinIO, Postgres, JWT, and qBittorrent in `.env.example`
- document and expose `DATA_DIR` for persistent storage
- export `DATA_DIR` in deployment script

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d8deeee30832ab25d8aca00581d18