### PR TITLE
Add Dockerfile for API service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . /app
+
+# Default command can be overridden by docker-compose
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add Python-based Dockerfile to support docker-compose builds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d90d2f88c832aa7d4309dde086964