### PR TITLE
Fix deploy script compose build context

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -100,15 +100,15 @@ read -p "Enter choice [1-3]: " choice
 case "$choice" in
   1)
     serve_compose=$(prepare_compose_with_free_ports compose.serve.yml)
-    docker compose -f "$serve_compose" up -d
+    docker compose --project-directory "$REPO_DIR" -f "$serve_compose" up -d
     rm "$serve_compose"
     ;;
   2)
-    docker compose -f compose.transcode.yml up -d
+    docker compose --project-directory "$REPO_DIR" -f compose.transcode.yml up -d
     ;;
   3)
     serve_compose=$(prepare_compose_with_free_ports compose.serve.yml)
-    docker compose -f "$serve_compose" -f compose.transcode.yml up -d
+    docker compose --project-directory "$REPO_DIR" -f "$serve_compose" -f compose.transcode.yml up -d
     rm "$serve_compose"
     ;;
   *)


### PR DESCRIPTION
## Summary
- ensure docker compose uses repository root when using temporary compose files

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d9643a914832a9d4a9863d97ed106