### PR TITLE
fix: check for occupied ports in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -17,7 +17,7 @@ prepare_compose_with_free_ports() {
   local dest=$(mktemp)
   cp "$src" "$dest"
   while IFS= read -r line; do
-    if [[ $line =~ -\ "([0-9]+):([0-9]+)" ]]; then
+    if [[ $line =~ \"([0-9]+):([0-9]+)\" ]]; then
       host_port="${BASH_REMATCH[1]}"
       container_port="${BASH_REMATCH[2]}"
       free_port=$(find_free_port "$host_port")


### PR DESCRIPTION
## Summary
- ensure deploy script detects occupied ports in compose files and substitutes free ones

## Testing
- `pytest`
- `bash -n deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_689d98758b1c832a803e87abd912f441