### PR TITLE
Fix deploy script to call python3

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -31,7 +31,7 @@ prepare_compose_with_free_ports() {
 }
 
 display_ports() {
-  python - "$@" <<'PY'
+  python3 - "$@" <<'PY'
 import sys, yaml
 ports = []
 for file in sys.argv[1:]:


### PR DESCRIPTION
## Summary
- use python3 instead of generic python in `deploy.sh`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d9fb8ff40832a87c62c2e77c29b9b