### PR TITLE
Ensure deploy script installs PyYAML

### DIFF
--- a/compose.serve.yml
+++ b/compose.serve.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   api:
     build: .

--- a/compose.transcode.yml
+++ b/compose.transcode.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   worker-ffmpeg:
     image: jrottenberg/ffmpeg:4.4-alpine

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,7 +30,19 @@ prepare_compose_with_free_ports() {
   echo "$dest"
 }
 
+ensure_pyyaml() {
+  python3 -c "import yaml" >/dev/null 2>&1 && return
+  echo "PyYAML module not found. Attempting to install..." >&2
+  if python3 -m pip install --user PyYAML >/dev/null 2>&1; then
+    echo "PyYAML installed." >&2
+  else
+    echo "Failed to install PyYAML. Port information will not be displayed." >&2
+    return 1
+  fi
+}
+
 display_ports() {
+  ensure_pyyaml || return
   python3 - "$@" <<'PY'
 import sys, yaml
 ports = []


### PR DESCRIPTION
## Summary
- Automatically install PyYAML when running deploy script to avoid missing module errors
- Remove obsolete version fields from docker compose files to silence warnings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689da25ea44c832a854568f280bbd880