### PR TITLE
fix qbittorrent port conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ bash deploy.sh
     ```
 
 该节点包含 Web 前端、API、Postgres、MinIO、Redis 以及 qBittorrent 下载引擎。下载完成后会通过 webhook 通知 API。
+qBittorrent 的 Web UI 将通过 <http://localhost:8081> 访问，以避免与网关端口冲突。
 
 ### 5. 手动部署 transcode 节点
 

--- a/compose.serve.yml
+++ b/compose.serve.yml
@@ -49,4 +49,6 @@ services:
       - ${DATA_DIR}/qbittorrent/config:/config
       - ${DATA_DIR}/qbittorrent/downloads:/downloads
       - ./scripts:/scripts:ro
+    ports:
+      - "8081:8080"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- expose qbittorrent web UI on port 8081 to avoid clash with gateway
- document qbittorrent WebUI port in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dad79b718832abec6be8548d0eb0f