### PR TITLE
feat: add basic search frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@
 - **BitMagnet Next Web**：提供种子检索与元数据展示界面。
 - **qBittorrent**：下载引擎，完成 BT 任务。
 - **API / MinIO**：供转码节点通信与存储使用。
+- **Seedbox Web 前端**：按规范提供媒体搜索与播放入口。
 - **FFmpeg Worker**（可选）：在独立节点执行视频切片与上传。
 
 默认开放的宿主机端口如下，可在 `.env` 中自定义：
 
 | 服务                | 端口 |
 | ------------------- | ---- |
+| Seedbox Web Frontend | 3001 |
 | BitMagnet Next Web  | 3000 |
 | qBittorrent Web UI  | 8081 |
 | API（转码通信）     | 8000 |
@@ -37,6 +39,7 @@
 
 3. 部署完成后即可访问：
 
+   - <http://localhost:3001> — Seedbox Web 前端
    - <http://localhost:3000> — BitMagnet Next Web
    - <http://localhost:8081> — qBittorrent
 

--- a/compose.serve.yml
+++ b/compose.serve.yml
@@ -8,6 +8,15 @@ services:
       - PYTHONPATH=/app
     ports:
       - "8000:8000"
+
+  web:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./web:/app
+    command: sh -c "npm install && npm run dev"
+    ports:
+      - "3001:3000"
   redis:
     image: redis:7
     volumes:

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,15 +1,54 @@
-import { useRouter } from 'next/router';
-import VideoPlayer from '../components/VideoPlayer';
+import { FormEvent, useState } from 'react';
+
+interface SearchResult {
+  id: string;
+  title?: string;
+  name?: string;
+}
 
 export default function Home() {
-  const router = useRouter();
-  const { src } = router.query;
-  const streamSrc = typeof src === 'string' ? src : '/hls/sample.m3u8';
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  async function onSearch(e: FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch(`http://localhost:8000/search?q=${encodeURIComponent(query)}`);
+      const data = await res.json();
+      setResults(data.results || []);
+    } catch (err) {
+      console.error('search failed', err);
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  }
 
   return (
-    <main style={{ padding: '2rem', textAlign: 'center' }}>
-      <h1>Seedbox Player</h1>
-      <VideoPlayer src={streamSrc} />
+    <main style={{ padding: '2rem' }}>
+      <h1>Media Search</h1>
+      <form onSubmit={onSearch} style={{ marginBottom: '1rem' }}>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search..."
+          style={{ padding: '0.5rem', width: '60%' }}
+        />
+        <button type="submit" style={{ marginLeft: '0.5rem', padding: '0.5rem 1rem' }}>
+          Go
+        </button>
+      </form>
+      {loading && <p>Loading...</p>}
+      {!loading && (
+        <ul>
+          {results.map((r) => (
+            <li key={r.id}>{r.title || r.name || r.id}</li>
+          ))}
+        </ul>
+      )}
     </main>
   );
 }
+


### PR DESCRIPTION
## Summary
- add simple search interface to Next.js frontend
- expose frontend through new `web` service in compose
- document frontend port and usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e8f1a6650832a9b902869bc947d7f