### PR TITLE
Fix web interface port detection and MinIO console port

### DIFF
--- a/compose.serve.yml
+++ b/compose.serve.yml
@@ -31,7 +31,7 @@ services:
       - ${DATA_DIR:-/opt/seedbox}/app-postgres:/var/lib/postgresql/data
   minio:
     image: minio/minio
-    command: server /data
+    command: server /data --console-address ":9090"
     environment:
       MINIO_ACCESS_KEY: minio
       MINIO_SECRET_KEY: minio123
@@ -39,6 +39,7 @@ services:
       - ${DATA_DIR:-/opt/seedbox}/minio:/data
     ports:
       - "9000:9000"
+      - "9090:9090"
   qbittorrent:
     image: lscr.io/linuxserver/qbittorrent:latest
     environment:

--- a/deploy.sh
+++ b/deploy.sh
@@ -71,7 +71,8 @@ else:
     print("Service port mappings:")
     for name, host, container in ports:
         print(f"  {host} -> {name} (container {container})")
-    web = next((host for name, host, _ in ports if name in ['gateway', 'bitmagnet-next-web']), None)
+    web_services = ['web', 'gateway', 'bitmagnet-next-web']
+    web = next((host for svc in web_services for name, host, _ in ports if name == svc), None)
     if web:
         print(f"Web interface available at http://localhost:{web}")
     else:


### PR DESCRIPTION
## Summary
- ensure deploy script identifies `web` service as main web interface
- configure MinIO console port to prevent random redirects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e981afbe4832aa2a1e291e3065bc5