### PR TITLE
Clarify Postgres host for local Docker

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -151,6 +151,7 @@ fi
 echo "Configure Bitmagnet Postgres connection:"
 if [ -z "${BITMAGNET_DB_HOST}" ]; then
   if [ -t 0 ]; then
+    echo "If Postgres runs in Docker on this machine, use a hostname reachable from containers (e.g., host.docker.internal)."
     read -p "Host: " BITMAGNET_DB_HOST
   else
     echo "BITMAGNET_DB_HOST is required." >&2


### PR DESCRIPTION
## Summary
- note to use a Docker-reachable hostname when prompting for Bitmagnet Postgres host

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eab1cb184832ab3f22959aa2129d2