### PR TITLE
fix: ensure data directory is absolute in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -140,6 +140,11 @@ if [ -z "${DATA_DIR}" ]; then
     DATA_DIR=/opt/seedbox
   fi
 fi
+
+# Ensure the data directory is an absolute path for Docker volume mounts
+if [[ "$DATA_DIR" != /* ]]; then
+  DATA_DIR="/$DATA_DIR"
+fi
 export DATA_DIR
 
 if [ "$choice" = "4" ]; then


### PR DESCRIPTION
## Summary
- ensure user-specified data directory is converted to an absolute path before Docker volume mounting

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ec0bc0d4c832ab380b5d80282107d