### PR TITLE
fix: media search uses configurable API base

### DIFF
--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -15,7 +15,8 @@ export default function Home() {
     e.preventDefault();
     setLoading(true);
     try {
-      const res = await fetch(`http://localhost:8000/search?q=${encodeURIComponent(query)}`);
+      const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || '';
+      const res = await fetch(`${apiBase}/search?q=${encodeURIComponent(query)}`);
       const data = await res.json();
       setResults(data.results || []);
     } catch (err) {


### PR DESCRIPTION
## Summary
- make media search API base URL configurable via `NEXT_PUBLIC_API_BASE_URL`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ec49188e0832ab707216652f7d191