### PR TITLE
Expose bitmagnet DSN to API container

### DIFF
--- a/compose.serve.yml
+++ b/compose.serve.yml
@@ -6,6 +6,7 @@ services:
       - ./:/app
     environment:
       - PYTHONPATH=/app
+      - BITMAGNET_RO_DSN=${BITMAGNET_RO_DSN}
     ports:
       - "8000:8000"
 


### PR DESCRIPTION
## Summary
- pass the Bitmagnet Postgres DSN to the API service so it can query the external database

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eca472d50832a815169028365db44