### PR TITLE
Add movie listing endpoint and DB deploy check

### DIFF
--- a/tests/test_movies.py
+++ b/tests/test_movies.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from api.main import app
+
+client = TestClient(app)
+
+def test_movies_endpoint():
+    response = client.get('/movies')
+    assert response.status_code == 200
+    data = response.json()
+    assert 'movies' in data
+    assert isinstance(data['movies'], list)

--- a/web/pages/movies.tsx
+++ b/web/pages/movies.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+interface Movie {
+  content_id: string;
+  title: string;
+  year?: string | null;
+  torrent_id: string;
+  torrent_name: string;
+  infohash: string;
+  size: number;
+}
+
+export default function Movies() {
+  const [movies, setMovies] = useState<Movie[]>([]);
+
+  useEffect(() => {
+    const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || '';
+    fetch(`${apiBase}/movies`)
+      .then((res) => res.json())
+      .then((data) => setMovies(data.movies || []))
+      .catch((err) => {
+        console.error('movies fetch failed', err);
+        setMovies([]);
+      });
+  }, []);
+
+  return (
+    <main style={{ padding: '2rem' }}>
+      <h1>Movies</h1>
+      <ul>
+        {movies.map((m) => (
+          <li key={`${m.content_id}-${m.torrent_id}`}>
+            {m.title} {m.year ? `(${m.year})` : ''} - {m.torrent_name}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- expose `/movies` API endpoint listing films with associated torrents
- verify movie data availability during deployment with sample query
- add web page and test for movies endpoint

## Testing
- `pytest -q`
- `cd web && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689eccf30160832aa666901211ceee49