### PR TITLE
Expose generic video content

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -118,63 +118,47 @@ async def search(q: Optional[str] = None):
         return {"results": [], "query": q}
 
 
-@app.get("/movies")
-async def movies():
+@app.get("/videos")
+async def videos():
     if bitmagnet_pool is None:
-        return {"movies": []}
+        return {"videos": []}
     query = """
-    WITH type_key AS (
-      SELECT name
+    WITH year_key AS (
+      SELECT key
       FROM public.content_attributes
-      WHERE lower(value) IN ('movie','film')
-      GROUP BY name
+      WHERE key ILIKE '%year%'
+      GROUP BY key
       ORDER BY COUNT(*) DESC
       LIMIT 1
-    ),
-    year_key AS (
-      SELECT name
-      FROM public.content_attributes
-      WHERE name ILIKE '%year%'
-      GROUP BY name
-      ORDER BY COUNT(*) DESC
-      LIMIT 1
-    ),
-    movies AS (
-      SELECT
-        c.id  AS content_id,
-        c.title,
-        ca_year.value AS year
-      FROM public.content c
-      LEFT JOIN public.content_attributes ca_type
-        ON ca_type.content_id = c.id
-       AND ca_type.name = (SELECT name FROM type_key)
-      LEFT JOIN public.content_attributes ca_year
-        ON ca_year.content_id = c.id
-       AND ca_year.name = (SELECT name FROM year_key)
-      WHERE lower(coalesce(ca_type.value,'')) IN ('movie','film')
     )
     SELECT
-      m.content_id,
-      m.title,
-      m.year,
+      c.id  AS content_id,
+      c.title,
+      c.type,
+      ca_year.value AS year,
       t.id       AS torrent_id,
       t.name     AS torrent_name,
       t.infohash,
       t.size
-    FROM movies m
-    JOIN public.torrent_contents tc ON tc.content_id = m.content_id
+    FROM public.content c
+    LEFT JOIN public.content_attributes ca_year
+      ON ca_year.content_type = c.type
+     AND ca_year.content_source = c.source
+     AND ca_year.content_id = c.id
+     AND ca_year.key = (SELECT key FROM year_key)
+    JOIN public.torrent_contents tc ON tc.content_id = c.id
     JOIN public.torrents        t  ON t.id         = tc.torrent_id
-    ORDER BY NULLIF(m.year,'')::int DESC NULLS LAST,
+    ORDER BY NULLIF(ca_year.value,'')::int DESC NULLS LAST,
              t.size DESC NULLS LAST
     LIMIT 50;
     """
     try:
         async with bitmagnet_pool.acquire() as conn:
             rows = await conn.fetch(query)
-        return {"movies": [dict(r) for r in rows]}
+        return {"videos": [dict(r) for r in rows]}
     except Exception as exc:
-        logger.error("movies query failed err=%s", exc)
-        return {"movies": []}
+        logger.error("videos query failed err=%s", exc)
+        return {"videos": []}
 
 
 @app.post("/tasks/fetch")

--- a/deploy.sh
+++ b/deploy.sh
@@ -207,29 +207,15 @@ fi
 echo "Bitmagnet Postgres connection successful."
 
 echo "Running sample movie query..."
-read -r -d '' MOVIE_QUERY <<'SQL'
-WITH type_key AS (
-  SELECT name
-  FROM public.content_attributes
-  WHERE lower(value) IN ('movie','film')
-  GROUP BY name
-  ORDER BY COUNT(*) DESC
-  LIMIT 1
-)
-SELECT c.id
-FROM public.content c
-LEFT JOIN public.content_attributes ca
-  ON ca.content_id = c.id
- AND ca.name = (SELECT name FROM type_key)
-WHERE lower(coalesce(ca.value,'')) IN ('movie','film')
-LIMIT 1;
+read -r -d '' CONTENT_QUERY <<'SQL'
+SELECT id FROM public.content LIMIT 1;
 SQL
 if ! docker run --rm -e PGPASSWORD="$BITMAGNET_DB_PASS" postgres:16-alpine \
-  psql -h "$BITMAGNET_DB_HOST" -p "$BITMAGNET_DB_PORT" -U "$BITMAGNET_DB_USER" -d "$BITMAGNET_DB_NAME" -c "$MOVIE_QUERY"; then
-  echo "Sample movie query failed. Aborting." >&2
+  psql -h "$BITMAGNET_DB_HOST" -p "$BITMAGNET_DB_PORT" -U "$BITMAGNET_DB_USER" -d "$BITMAGNET_DB_NAME" -c "$CONTENT_QUERY"; then
+  echo "Sample content query failed. Aborting." >&2
   exit 1
 fi
-echo "Sample movie query successful."
+  echo "Sample content query successful."
 
 export BITMAGNET_RO_DSN="postgresql://${BITMAGNET_DB_USER}:${BITMAGNET_DB_PASS}@${BITMAGNET_DB_HOST}:${BITMAGNET_DB_PORT}/${BITMAGNET_DB_NAME}"
 

--- a/tests/test_videos.py
+++ b/tests/test_videos.py
@@ -10,9 +10,9 @@ from api.main import app
 
 client = TestClient(app)
 
-def test_movies_endpoint():
-    response = client.get('/movies')
+def test_videos_endpoint():
+    response = client.get('/videos')
     assert response.status_code == 200
     data = response.json()
-    assert 'movies' in data
-    assert isinstance(data['movies'], list)
+    assert 'videos' in data
+    assert isinstance(data['videos'], list)

--- a/web/pages/videos.tsx
+++ b/web/pages/videos.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 
-interface Movie {
+interface Video {
   content_id: string;
   title: string;
+  type: string;
   year?: string | null;
   torrent_id: string;
   torrent_name: string;
@@ -10,25 +11,25 @@ interface Movie {
   size: number;
 }
 
-export default function Movies() {
-  const [movies, setMovies] = useState<Movie[]>([]);
+export default function Videos() {
+  const [videos, setVideos] = useState<Video[]>([]);
 
   useEffect(() => {
     const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || '';
-    fetch(`${apiBase}/movies`)
+    fetch(`${apiBase}/videos`)
       .then((res) => res.json())
-      .then((data) => setMovies(data.movies || []))
+      .then((data) => setVideos(data.videos || []))
       .catch((err) => {
-        console.error('movies fetch failed', err);
-        setMovies([]);
+        console.error('videos fetch failed', err);
+        setVideos([]);
       });
   }, []);
 
   return (
     <main style={{ padding: '2rem' }}>
-      <h1>Movies</h1>
+      <h1>Videos</h1>
       <ul>
-        {movies.map((m) => (
+        {videos.map((m) => (
           <li key={`${m.content_id}-${m.torrent_id}`}>
             {m.title} {m.year ? `(${m.year})` : ''} - {m.torrent_name}
           </li>


### PR DESCRIPTION
## Summary
- query Bitmagnet for any content instead of only movies during deploy
- expose `/videos` endpoint to list all content types
- update frontend and tests for the new `/videos` route

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ecfd15dec832a976c780f2b717133