### PR TITLE
Expose magnet links in search and video APIs

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from api.main import app
+
+client = TestClient(app)
+
+def test_search_endpoint():
+    response = client.get('/search', params={'q': 'test'})
+    assert response.status_code == 200
+    data = response.json()
+    assert 'results' in data
+    assert 'query' in data and data['query'] == 'test'
+    assert isinstance(data['results'], list)
+    if data['results']:
+        assert 'magnet' in data['results'][0]

--- a/tests/test_videos.py
+++ b/tests/test_videos.py
@@ -16,3 +16,5 @@ def test_videos_endpoint():
     data = response.json()
     assert 'videos' in data
     assert isinstance(data['videos'], list)
+    if data['videos']:
+        assert 'magnet' in data['videos'][0]


### PR DESCRIPTION
## Summary
- include torrent name, content title, size, and magnet link in `/search`
- return magnet links for `/videos` query
- add tests for search and ensure videos include magnet field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ee3afc7a4832a8294c9cee1095fc6