### PR TITLE
Add login and Postgres config with query debugging

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3,6 +3,10 @@ import os
 from pydantic import BaseModel
 
 DB_PATH = os.environ.get("APP_DB", "app.db")
+POSTGRES_DSN_DEFAULT = os.environ.get(
+    "BITMAGNET_RO_DSN",
+    "postgresql://postgres@84.54.3.69:5433/bitmagnet",
+)
 
 
 class AppConfig(BaseModel):
@@ -10,6 +14,7 @@ class AppConfig(BaseModel):
 
     download_dir: str = "/downloads"
     ffmpeg_preset: str = "fast"
+    postgres_dsn: str = POSTGRES_DSN_DEFAULT
 
 
 def init_db() -> None:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -134,6 +134,31 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
       security:
       - HTTPBearer: []
+  /admin/query:
+    post:
+      summary: Run SQL query
+      operationId: admin_query_admin_query_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SQLQuery'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryResult'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /items/{item_id}:
     get:
       summary: Get Item
@@ -318,6 +343,10 @@ components:
           type: string
           title: Ffmpeg Preset
           default: fast
+        postgres_dsn:
+          type: string
+          title: Postgres Dsn
+          default: postgresql://postgres@84.54.3.69:5433/bitmagnet
       type: object
       title: AppConfig
       description: Application configuration stored in the database.
@@ -375,6 +404,26 @@ components:
       - role
       - exp
       title: LoginResponse
+    SQLQuery:
+      properties:
+        sql:
+          type: string
+          title: Sql
+      type: object
+      required:
+      - sql
+      title: SQLQuery
+    QueryResult:
+      properties:
+        rows:
+          items:
+            type: object
+          type: array
+          title: Rows
+      type: object
+      required:
+      - rows
+      title: QueryResult
     ValidationError:
       properties:
         loc:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from api.main import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def auth_headers():
+    return {"Authorization": "Bearer fake-jwt"}
+
+
+def test_admin_query_requires_auth():
+    resp = client.post("/admin/query", json={"sql": "SELECT 1"})
+    assert resp.status_code == 403
+
+
+def test_admin_query_with_auth():
+    resp = client.post(
+        "/admin/query", json={"sql": "SELECT 1"}, headers=auth_headers()
+    )
+    assert resp.status_code == 200
+    assert "rows" in resp.json()

--- a/web/pages/admin/config.tsx
+++ b/web/pages/admin/config.tsx
@@ -3,14 +3,17 @@ import { useState, useEffect, ChangeEvent } from 'react';
 interface Config {
   download_dir: string;
   ffmpeg_preset: string;
+  postgres_dsn?: string;
 }
 
 export default function ConfigPage() {
   const [config, setConfig] = useState<Config>({ download_dir: '', ffmpeg_preset: '' });
 
   useEffect(() => {
-    fetch('http://localhost:8000/admin/config', {
-      headers: { Authorization: 'Bearer fake-jwt' }
+    const token = localStorage.getItem('token');
+    const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || '';
+    fetch(`${apiBase}/admin/config`, {
+      headers: { Authorization: `Bearer ${token}` }
     })
       .then((res) => res.json())
       .then(setConfig);
@@ -21,11 +24,13 @@ export default function ConfigPage() {
   };
 
   const save = async () => {
-    await fetch('http://localhost:8000/admin/config', {
+    const token = localStorage.getItem('token');
+    const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || '';
+    await fetch(`${apiBase}/admin/config`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: 'Bearer fake-jwt'
+        Authorization: `Bearer ${token}`
       },
       body: JSON.stringify(config)
     });

--- a/web/pages/admin/postgres.tsx
+++ b/web/pages/admin/postgres.tsx
@@ -1,0 +1,94 @@
+import { useState, useEffect, ChangeEvent } from 'react';
+
+interface Config {
+  download_dir: string;
+  ffmpeg_preset: string;
+  postgres_dsn: string;
+}
+
+export default function PostgresPage() {
+  const [config, setConfig] = useState<Config>({
+    download_dir: '',
+    ffmpeg_preset: '',
+    postgres_dsn: ''
+  });
+  const [sql, setSql] = useState('');
+  const [rows, setRows] = useState<any[]>([]);
+  const [error, setError] = useState('');
+
+  const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || '';
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    fetch(`${apiBase}/admin/config`, {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+      .then((res) => res.json())
+      .then(setConfig);
+  }, []);
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setConfig({ ...config, postgres_dsn: e.target.value });
+  };
+
+  const save = async () => {
+    const token = localStorage.getItem('token');
+    await fetch(`${apiBase}/admin/config`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(config)
+    });
+    alert('saved');
+  };
+
+  const runQuery = async () => {
+    const token = localStorage.getItem('token');
+    const res = await fetch(`${apiBase}/admin/query`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ sql })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setRows(data.rows || []);
+      setError('');
+    } else {
+      const text = await res.text();
+      setError(text);
+      setRows([]);
+    }
+  };
+
+  return (
+    <main style={{ padding: '2rem' }}>
+      <h1>Postgres Config</h1>
+      <div>
+        <label>
+          DSN
+          <input value={config.postgres_dsn} onChange={onChange} style={{ width: '100%' }} />
+        </label>
+        <button onClick={save}>Save</button>
+      </div>
+      <h2>Query</h2>
+      <textarea
+        value={sql}
+        onChange={(e) => setSql(e.target.value)}
+        rows={5}
+        style={{ width: '100%' }}
+      />
+      <button onClick={runQuery}>Run</button>
+      {error && <pre>{error}</pre>}
+      <ul>
+        {rows.map((r, i) => (
+          <li key={i}>{JSON.stringify(r)}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/web/pages/login.tsx
+++ b/web/pages/login.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || '';
+    const res = await fetch(`${apiBase}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      router.push('/admin/postgres');
+    } else {
+      alert('login failed');
+    }
+  };
+
+  return (
+    <main style={{ padding: '2rem' }}>
+      <h1>Login</h1>
+      <form onSubmit={onSubmit}>
+        <div>
+          <input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Username"
+          />
+        </div>
+        <div>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+          />
+        </div>
+        <button type="submit">Login</button>
+      </form>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- allow configuring Postgres DSN via backend config
- add admin SQL query endpoint for debugging
- provide login page and Postgres admin page with query runner

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a287a743a0832ab1d6c7b7abd61df0