### PR TITLE
Add login navigation to web UI

### DIFF
--- a/web/pages/admin/config.tsx
+++ b/web/pages/admin/config.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, ChangeEvent } from 'react';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 interface Config {
   download_dir: string;
@@ -53,6 +54,9 @@ export default function ConfigPage() {
 
   return (
     <main>
+      <nav style={{ marginBottom: '1rem' }}>
+        <Link href="/admin/postgres">Postgres</Link>
+      </nav>
       <h1>Configuration</h1>
       <div>
         <label>

--- a/web/pages/admin/postgres.tsx
+++ b/web/pages/admin/postgres.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, ChangeEvent } from 'react';
+import Link from 'next/link';
 
 interface Config {
   download_dir: string;
@@ -67,6 +68,9 @@ export default function PostgresPage() {
 
   return (
     <main style={{ padding: '2rem' }}>
+      <nav style={{ marginBottom: '1rem' }}>
+        <Link href="/admin/config">User Config</Link>
+      </nav>
       <h1>Postgres Config</h1>
       <div>
         <label>

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useState } from 'react';
+import Link from 'next/link';
 
 interface SearchResult {
   id: string;
@@ -29,7 +30,10 @@ export default function Home() {
 
   return (
     <main style={{ padding: '2rem' }}>
-      <h1>Media Search</h1>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h1>Media Search</h1>
+        <Link href="/login">Login</Link>
+      </div>
       <form onSubmit={onSearch} style={{ marginBottom: '1rem' }}>
         <input
           value={query}


### PR DESCRIPTION
## Summary
- add login button on search page
- link admin pages for database and user config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a28dc8b164832a8970430f96ed55ca