### PR TITLE
feat: log query on admin page

### DIFF
--- a/web/pages/admin/postgres.tsx
+++ b/web/pages/admin/postgres.tsx
@@ -17,6 +17,7 @@ export default function PostgresPage() {
   const [keyword, setKeyword] = useState('');
   const [rows, setRows] = useState<any[]>([]);
   const [error, setError] = useState('');
+  const [logs, setLogs] = useState<string[]>([]);
 
   const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || '';
 
@@ -54,6 +55,7 @@ export default function PostgresPage() {
       "SELECT encode(info_hash, 'hex') AS id, name FROM public.torrents WHERE name ILIKE '%" +
       safe +
       "%' LIMIT 20";
+    setLogs((prev) => [...prev, `Executing: ${sql}`]);
     const res = await fetch(`${apiBase}/admin/query`, {
       method: 'POST',
       headers: {
@@ -66,10 +68,12 @@ export default function PostgresPage() {
       const data = await res.json();
       setRows(data.rows || []);
       setError('');
+      setLogs((prev) => [...prev, `Rows: ${data.rows?.length || 0}`]);
     } else {
       const text = await res.text();
       setError(text);
       setRows([]);
+      setLogs((prev) => [...prev, `Error: ${text}`]);
     }
   };
 
@@ -100,6 +104,8 @@ export default function PostgresPage() {
           <li key={i}>{JSON.stringify(r)}</li>
         ))}
       </ul>
+      <h2>Logs</h2>
+      <pre>{logs.join('\n')}</pre>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- display query execution logs on Postgres admin page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2942455e0832a819aeeba37c66302