### PR TITLE
Use websearch syntax for FTS

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -126,7 +126,7 @@ async def search(q: Optional[str] = None):
                        ON c.type   = tc.content_type
                       AND c.source = tc.content_source
                       AND c.id     = tc.content_id
-                WHERE tc.tsv @@ plainto_tsquery('simple', $1)
+                WHERE tc.tsv @@ websearch_to_tsquery('simple', $1)
                 ORDER BY tc.created_at DESC
                 LIMIT 10
                 """,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -23,7 +23,7 @@ class DummyConn:
 
     async def fetch(self, sql, param=None):
         self.calls.append((sql, param))
-        if 'plainto_tsquery' in sql:
+        if 'websearch_to_tsquery' in sql:
             return []
         return [
             {
@@ -63,3 +63,5 @@ def test_search_fallback_ilike(monkeypatch):
     data = response.json()
     assert data['query'] == 'demo'
     assert data['results'] and data['results'][0]['torrent_name'] == 'demo'
+    # ensure full-text search attempted first
+    assert any('websearch_to_tsquery' in sql for sql, _ in pool.conn.calls)


### PR DESCRIPTION
## Summary
- switch search SQL to use Postgres websearch_to_tsquery for better query handling
- adjust search tests to reflect websearch syntax

## Testing
- `pytest tests/test_search.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2b783b614832a908ba9eac2a2a61c