### PR TITLE
chore: detect Windows environments in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,11 @@ set -e
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$REPO_DIR"
 
+# Example environment check: detect Windows systems
+if uname | grep -qi "windows"; then
+  echo "Detected Windows environment; this script targets Unix-like systems."
+fi
+
 CONFIG_FILE="$REPO_DIR/deploy.conf"
 if [ -f "$CONFIG_FILE" ]; then
   source "$CONFIG_FILE"


### PR DESCRIPTION
## Summary
- detect Windows environments early in deploy script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2bc397a6c832ab83b1ae76386b88d