### PR TITLE
Fix web search result display

### DIFF
--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -5,6 +5,7 @@ interface SearchResult {
   id: string;
   title?: string;
   name?: string;
+  torrent_name?: string;
 }
 
 export default function Home() {
@@ -49,7 +50,7 @@ export default function Home() {
       {!loading && (
         <ul>
           {results.map((r) => (
-            <li key={r.id}>{r.title || r.name || r.id}</li>
+            <li key={r.id}>{r.title || r.torrent_name || r.name || r.id}</li>
           ))}
         </ul>
       )}


### PR DESCRIPTION
## Summary
- display torrent name from API search results on web frontend

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a2cd5a6e28832a99795649eeda1970