### PR TITLE
feat: hardcode bitmagnet database link

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3,10 +3,7 @@ import os
 from pydantic import BaseModel
 
 DB_PATH = os.environ.get("APP_DB", "app.db")
-POSTGRES_DSN_DEFAULT = os.environ.get(
-    "BITMAGNET_RO_DSN",
-    "postgresql://postgres@84.54.3.69:5433/bitmagnet",
-)
+POSTGRES_DSN_DEFAULT = "postgresql://postgres:postgres666@84.54.3.69:5433/bitmagnet"
 
 
 class AppConfig(BaseModel):


### PR DESCRIPTION
## Summary
- hardcode Bitmagnet Postgres DSN into default configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2d139a48c832a92a2e88fff7aa1be