### PR TITLE
Add cross-platform deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,15 @@
 ```bash
 git clone https://github.com/podcctv/seedbox.git
 cd seedbox
-bash deploy.sh
+bash deploy.sh        # Linux / macOS
+```
+
+或在 Windows 上使用 PowerShell：
+
+```powershell
+git clone https://github.com/podcctv/seedbox.git
+cd seedbox
+pwsh deploy.ps1
 ```
 
 ### 启动下载节点

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,11 @@
+#!/usr/bin/env pwsh
+param()
+
+$files = @('compose.download.yml', 'compose.worker.yml')
+foreach ($file in $files) {
+  if (Test-Path $file) {
+    docker compose -f $file up -d
+  } else {
+    Write-Host "Missing $file; skipping."
+  }
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy download and worker nodes using docker compose files if present
+for file in compose.download.yml compose.worker.yml; do
+  if [[ -f "$file" ]]; then
+    docker compose -f "$file" up -d
+  else
+    echo "Missing $file; skipping."
+  fi
+done


### PR DESCRIPTION
## Summary
- add `deploy.sh` and `deploy.ps1` for starting download and worker nodes
- document bash and PowerShell deployment commands in README

## Testing
- `gofmt -w download/main.go download/main_test.go`
- `black worker/worker.py worker/test_worker.py`
- `npx prettier frontend/src/main.js --write`
- `go test ./...`
- `pytest`
- `cd frontend && npm test && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68a2df2c43f0832a9e705322020dee53