### PR TITLE
Refactor deploy script for new architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pwsh deploy.ps1
 ### 启动下载节点
 
 ```bash
-docker compose -f compose.download.yml up -d
+docker compose -f download/docker-compose.yml up -d
 ```
 
 访问：
@@ -64,7 +64,7 @@ docker compose -f compose.download.yml up -d
 ### 启动处理节点
 
 ```bash
-docker compose -f compose.worker.yml up -d
+docker compose -f worker/docker-compose.yml up -d
 ```
 
 处理节点自动轮询新任务并回传预览图。

--- a/SEEDBOX_SPEC.md
+++ b/SEEDBOX_SPEC.md
@@ -82,7 +82,7 @@ API_TOKEN=CHANGE_ME
 
 ## 7. 部署说明
 
-- 两个节点各自拥有独立的 `docker compose` 文件。
+- 两个节点各自拥有独立的 `docker compose` 文件（位于 `download/docker-compose.yml` 与 `worker/docker-compose.yml`）。
 - 下载与预览目录使用卷挂载以保证持久化。
 - 处理节点需具备访问下载节点 API 的网络权限。
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,10 +2,14 @@
 set -euo pipefail
 
 # Deploy download and worker nodes using docker compose files if present
-for file in compose.download.yml compose.worker.yml; do
-  if [[ -f "$file" ]]; then
-    docker compose -f "$file" up -d
+for dir in download worker; do
+  compose_file="$dir/docker-compose.yml"
+  if [[ -f "$compose_file" ]]; then
+    (
+      cd "$dir"
+      docker compose up -d
+    )
   else
-    echo "Missing $file; skipping."
+    echo "Missing $compose_file; skipping."
   fi
 done


### PR DESCRIPTION
## Summary
- Refactor deploy script to start download and worker nodes from their own directories
- Document new compose file locations in README and SEEDBOX_SPEC

## Testing
- `go test ./...`
- `pytest`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a2e14aa568832aace396bed79a4641