### PR TITLE
Add docker compose files for download and worker nodes

### DIFF
--- a/download/docker-compose.yml
+++ b/download/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.8"
+services:
+  api:
+    image: golang:1.21-alpine
+    working_dir: /app
+    volumes:
+      - ./:/app
+    command: go run main.go
+    ports:
+      - "8000:8000"
+  transmission:
+    image: lscr.io/linuxserver/transmission:latest
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+    volumes:
+      - ./downloads:/downloads
+    ports:
+      - "9091:9091"
+      - "51413:51413"
+      - "51413:51413/udp"

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+services:
+  worker:
+    image: python:3.11-alpine
+    working_dir: /app
+    volumes:
+      - ./:/app
+    environment:
+      - API_URL=http://localhost:8000
+      - API_TOKEN=token
+    command: sh -c "pip install requests && python worker.py"


### PR DESCRIPTION
## Summary
- add docker compose configuration for the download node, including Transmission and the Go API
- add docker compose configuration for the worker node to run the Python worker

## Testing
- `go test ./...`
- `pytest`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2e50e8eac832a9d85a2a8a0922249