### PR TITLE
fix: move API to port 28000

### DIFF
--- a/SEEDBOX_SPEC.md
+++ b/SEEDBOX_SPEC.md
@@ -20,26 +20,28 @@
 ```
 
 ### 下载节点（A）
+
 - Transmission-daemon：BT 下载，端口 9091
-- Gin API：提供任务管理、条目编辑/删除、预览接收等接口，端口 8000
+- Gin API：提供任务管理、条目编辑/删除、预览接收等接口，端口 28000
 - Vue 3 + Vite 前端：预览墙，端口 3001
 - SQLite：存储条目信息及任务状态
 
 ### 处理节点（B）
+
 - Python 3 脚本：轮询下载节点获取待处理任务
 - FFmpeg：生成预览拼图（如 `fps=1/10, scale=320:-1, tile=5x5`）
 - HTTP 客户端：将生成的预览图通过 `POST /api/jobs/:id/done` 回传
 
 ## 2. 技术选型
 
-| 模块            | 技术           |
-| --------------- | -------------- |
-| 前端            | Vue 3 + Vite + Tailwind |
-| 后端 API       | Go 1.21 + Gin  |
-| BT 客户端      | Transmission-daemon |
-| 数据库          | SQLite         |
-| 处理节点脚本    | Python 3 + FFmpeg |
-| 通信方式        | HTTP/JSON，简单 Token 鉴权 |
+| 模块         | 技术                       |
+| ------------ | -------------------------- |
+| 前端         | Vue 3 + Vite + Tailwind    |
+| 后端 API     | Go 1.21 + Gin              |
+| BT 客户端    | Transmission-daemon        |
+| 数据库       | SQLite                     |
+| 处理节点脚本 | Python 3 + FFmpeg          |
+| 通信方式     | HTTP/JSON，简单 Token 鉴权 |
 
 ## 3. 预览墙功能
 
@@ -90,4 +92,3 @@ API_TOKEN=CHANGE_ME
 
 - 单元测试：`pytest`
 - 恢复流程：重新启动容器 → 挂载原有数据目录 → 确认 API 与 Transmission 正常工作。
-

--- a/download/docker-compose.yml
+++ b/download/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./:/app
     command: go run main.go
     ports:
-      - "8000:8000"
+      - "28000:28000"
   transmission:
     image: lscr.io/linuxserver/transmission:latest
     environment:

--- a/download/main.go
+++ b/download/main.go
@@ -49,5 +49,5 @@ func setupRouter() *gin.Engine {
 }
 
 func main() {
-	setupRouter().Run(":8000")
+	setupRouter().Run(":28000")
 }

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     volumes:
       - ./:/app
     environment:
-      - API_URL=http://localhost:8000
+      - API_URL=http://localhost:28000
       - API_TOKEN=token
     command: sh -c "pip install requests && python worker.py"

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import requests
 
-API_URL = os.getenv("API_URL", "http://localhost:8000")
+API_URL = os.getenv("API_URL", "http://localhost:28000")
 API_TOKEN = os.getenv("API_TOKEN", "token")
 
 


### PR DESCRIPTION
## Summary
- change download API to listen on port 28000
- update worker config and docs to new port

## Testing
- `go test ./...`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2e7e41bb0832aac5ccf6193f70256