### PR TITLE
Remove deprecated compose version fields

### DIFF
--- a/download/docker-compose.yml
+++ b/download/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   api:
     image: golang:1.21-alpine

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   worker:
     image: python:3.11-alpine


### PR DESCRIPTION
## Summary
- drop obsolete `version` declaration from download and worker compose files

## Testing
- `go test ./...`
- `pytest`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a2ed704398832aacd008389731158f