### PR TITLE
Add web management interface for node configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - Transmission-daemon 处理 BT 下载
 - Go (Gin) API 提供编辑、删除及任务接口
 - Vue 3 + Vite 前端展示预览墙
+- Web 管理页面配置节点通信参数
 - SQLite 存储条目信息
 
 处理节点组件：
@@ -60,6 +61,7 @@ docker compose -f download/docker-compose.yml up -d
 
 - <http://localhost:3001> — 预览墙
 - <http://localhost:9091> — Transmission Web UI
+- <http://localhost:28000/admin/> — 管理页面
 
 ### 启动处理节点
 

--- a/SEEDBOX_SPEC.md
+++ b/SEEDBOX_SPEC.md
@@ -25,6 +25,7 @@
 - Gin API：提供任务管理、条目编辑/删除、预览接收等接口，端口 28000
 - Vue 3 + Vite 前端：预览墙，端口 3001
 - SQLite：存储条目信息及任务状态
+- Web 管理页面：配置节点通信参数
 
 ### 处理节点（B）
 
@@ -59,6 +60,8 @@ PATCH  /items/:id                      -> 编辑条目
 DELETE /items/:id                      -> 删除条目与文件
 POST   /jobs/next                      -> 处理节点获取下一个任务
 POST   /jobs/:id/done {sprite}         -> 上传预览图（multipart/form-data）
+GET    /config                         -> 获取节点配置
+POST   /config {downloadDir,port,workerAddr} -> 更新配置
 ```
 
 鉴权：所有请求需在 Header 中携带 `X-Auth: <token>`。

--- a/download/main.go
+++ b/download/main.go
@@ -24,27 +24,47 @@ type Item struct {
 
 var items = []Item{{ID: 1, Title: "Sample", Status: "ready"}}
 
+type Config struct {
+	DownloadDir string `json:"downloadDir"`
+	Port        int    `json:"port"`
+	WorkerAddr  string `json:"workerAddr"`
+}
+
+var cfg = Config{DownloadDir: "/downloads", Port: 28000, WorkerAddr: "http://localhost:9001"}
+
 func setupRouter() *gin.Engine {
 	r := gin.Default()
-	r.Use(authMiddleware)
-	r.GET("/items", func(c *gin.Context) {
+	api := r.Group("/")
+	api.Use(authMiddleware)
+	api.GET("/items", func(c *gin.Context) {
 		c.JSON(http.StatusOK, items)
 	})
-	r.POST("/tasks/fetch", func(c *gin.Context) {
+	api.POST("/tasks/fetch", func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
-	r.PATCH("/items/:id", func(c *gin.Context) {
+	api.PATCH("/items/:id", func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
-	r.DELETE("/items/:id", func(c *gin.Context) {
+	api.DELETE("/items/:id", func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
-	r.POST("/jobs/next", func(c *gin.Context) {
+	api.POST("/jobs/next", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"id": 1, "path": "/tmp/video.mp4"})
 	})
-	r.POST("/jobs/:id/done", func(c *gin.Context) {
+	api.POST("/jobs/:id/done", func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
+	api.GET("/config", func(c *gin.Context) {
+		c.JSON(http.StatusOK, cfg)
+	})
+	api.POST("/config", func(c *gin.Context) {
+		if err := c.BindJSON(&cfg); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.Status(http.StatusOK)
+	})
+	r.Static("/admin", "../frontend")
 	return r
 }
 

--- a/download/main_test.go
+++ b/download/main_test.go
@@ -26,3 +26,14 @@ func TestAuthMissing(t *testing.T) {
 		t.Fatalf("expected 401, got %d", w.Code)
 	}
 }
+
+func TestGetConfig(t *testing.T) {
+	router := setupRouter()
+	req, _ := http.NewRequest("GET", "/config", nil)
+	req.Header.Set("X-Auth", authToken)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Seedbox Config</title>
+  </head>
+  <body>
+    <h1>Node Configuration</h1>
+    <form id="configForm">
+      <label>Download Directory <input id="downloadDir" /></label><br />
+      <label>Port <input id="port" type="number" /></label><br />
+      <label>Worker Address <input id="workerAddr" /></label><br />
+      <button type="submit">Save</button>
+    </form>
+    <script src="src/main.js"></script>
+  </body>
+</html>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,3 +1,28 @@
-export function greet(name) {
-  return `Hello ${name}`;
+async function loadConfig() {
+  const resp = await fetch("/config", { headers: { "X-Auth": "token" } });
+  if (!resp.ok) return;
+  const cfg = await resp.json();
+  document.getElementById("downloadDir").value = cfg.downloadDir;
+  document.getElementById("port").value = cfg.port;
+  document.getElementById("workerAddr").value = cfg.workerAddr;
 }
+
+document.getElementById("configForm").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const cfg = {
+    downloadDir: document.getElementById("downloadDir").value,
+    port: parseInt(document.getElementById("port").value, 10),
+    workerAddr: document.getElementById("workerAddr").value,
+  };
+  await fetch("/config", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Auth": "token",
+    },
+    body: JSON.stringify(cfg),
+  });
+  alert("Saved");
+});
+
+loadConfig();


### PR DESCRIPTION
## Summary
- expose configurable node settings via new `/config` API
- serve a simple admin page for adjusting download directory, port and worker address
- document the management interface and configuration endpoints

## Testing
- `gofmt -w download/main.go download/main_test.go`
- `npx prettier -w frontend/src/main.js frontend/index.html`
- `black worker/worker.py worker/test_worker.py`
- `go test ./...`
- `pytest`
- `cd frontend && npm test && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68a2f17eac44832ab77a5f9eec86bca0