### PR TITLE
Fix Transmission setup by ensuring required directories exist

### DIFF
--- a/download/docker-compose.yml
+++ b/download/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - TZ=Etc/UTC
     volumes:
       - ./downloads:/downloads
+      - ./watch:/watch
     ports:
       - "9091:9091"
       - "51413:51413"

--- a/download/downloads/complete/.gitkeep
+++ b/download/downloads/complete/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory exists

--- a/download/downloads/incomplete/.gitkeep
+++ b/download/downloads/incomplete/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory exists

--- a/download/watch/.gitkeep
+++ b/download/watch/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory exists


### PR DESCRIPTION
## Summary
- Map a watch folder into the Transmission container
- Add placeholders for complete and incomplete download directories to avoid startup errors

## Testing
- `go test ./...`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f8cd00e4832abcf56eced84a0a5a