### PR TITLE
Align download module with Go 1.21

### DIFF
--- a/download/go.mod
+++ b/download/go.mod
@@ -1,6 +1,6 @@
 module download
 
-go 1.24.3
+go 1.21
 
 require (
 	github.com/gin-gonic/gin v1.10.1


### PR DESCRIPTION
## Summary
- lower download module go requirement to 1.21 so it builds on older toolchains

## Testing
- `go test ./...` (from download)
- `pytest worker/test_worker.py`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2fab5c654832aa4d797059022e6ee