### PR TITLE
Handle worker connection errors

### DIFF
--- a/worker/test_worker.py
+++ b/worker/test_worker.py
@@ -1,5 +1,6 @@
 import worker
 from unittest.mock import patch
+import requests
 
 
 def test_next_job_sends_token():
@@ -18,3 +19,14 @@ def test_report_done_uses_file(tmp_path):
         worker.report_done(1, str(dummy))
         assert post.call_args.args[0].endswith("/jobs/1/done")
         assert "files" in post.call_args.kwargs
+
+
+def test_run_handles_connection_errors():
+    with patch("worker.next_job", side_effect=requests.ConnectionError), patch(
+        "time.sleep", side_effect=KeyboardInterrupt
+    ) as sleep:
+        try:
+            worker.run()
+        except KeyboardInterrupt:
+            pass
+        sleep.assert_called()

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -68,6 +68,10 @@ def run(poll_interval: int = 5) -> None:
                 time.sleep(poll_interval)
                 continue
             raise
+        except requests.RequestException:
+            # Network issues like connection errors should not crash the worker
+            time.sleep(poll_interval)
+            continue
         process(job)
 
 


### PR DESCRIPTION
## Summary
- retry job polling on network failures
- test worker retry behavior when API is unreachable

## Testing
- `pytest`
- `go test ./...`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3cc89a334832aaa5e0749ac0aa1be